### PR TITLE
Adapt Makefile to be usable in kmp packaging

### DIFF
--- a/ibmvmc/Makefile
+++ b/ibmvmc/Makefile
@@ -5,12 +5,8 @@ obj-m := ibmvmc.o
 
 KDIR  := /lib/modules/$(shell uname -r)/build
 
-all:
-	$(MAKE) -C $(KDIR) M=$(PWD) modules
+default: modules
+install: modules_install
 
-clean:
-	$(MAKE) -C $(KDIR) M=$(PWD) clean
-
-# Temporary until I come up with a better way
-install:
-	mknod /dev/ibmvmc c 249 0
+modules modules_install clean:
+	$(MAKE) -C $(KDIR) M=$(PWD) $@


### PR DESCRIPTION
Rework Makefile a littlebit, so the module could be
packaged as kmp. Put temporary mknod into mknod rule,
as it really optional and shouldn't be called as install step.

Signed-off-by: Dinar Valeev dvaleev@suse.com
