### PR TITLE
Use misc minor

### DIFF
--- a/ibmvmc/ibmvmc.h
+++ b/ibmvmc/ibmvmc.h
@@ -1,7 +1,7 @@
 /*
  * IBM Power Systems Virtual Management Channel Support.
  *
- * Copyright (c) 2004, 2015 IBM Corp.
+ * Copyright (c) 2004, 2016 IBM Corp.
  *   Dave Engebretsen engebret@us.ibm.com
  *   Steven Royer seroyer@linux.vnet.ibm.com
  *   Adam Reznechek adreznec@linux.vnet.ibm.com


### PR DESCRIPTION
Register as a miscdev and dynamically allocate a minor for the ibmvmc
node instead of reserving an entire major.

Signed-off-by: Steven Royer seroyer@us.ibm.com
