### PR TITLE
4.11 kernel support

### DIFF
--- a/ibmvmc/ibmvmc.c
+++ b/ibmvmc/ibmvmc.c
@@ -33,6 +33,7 @@
 #include <linux/uaccess.h>
 #include <linux/io.h>
 #include <linux/miscdevice.h>
+#include <linux/sched/signal.h>
 
 #include <asm/byteorder.h>
 #include <asm/irq.h>


### PR DESCRIPTION
signal_pending moved to linux/sched/signal.h

Signed-off-by: Steven Royer <seroyer@linux.vnet.ibm.com>